### PR TITLE
Use `codecov-action@v2` to upload coverage to codecov and add missing deps.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-service-context-store ChangeLog
 
+## 3.1.0 - 2022-03-TBD
+
+### Added
+- Add missing dependency `cors@2.8.5`.
+- Add missing dependencies `@digitalbazaar/ed25519-signature-2020@3.0` and
+  `@digitalbazaar/http-client@2.0.1` in test.
+
 ## 3.0.0 - 2022-03-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-service-context-store",
   "dependencies": {
+    "cors": "^2.8.5",
     "esm": "^3.2.25"
   },
   "peerDependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -9,8 +9,10 @@
     "coverage-report": "nyc report"
   },
   "dependencies": {
+    "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/edv-client": "^13.0.0",
     "@digitalbazaar/ezcap": "^2.0.2",
+    "@digitalbazaar/http-client": "^2.0.1",
     "@digitalbazaar/webkms-client": "^10.0.0",
     "bedrock": "^4.4.3",
     "bedrock-app-identity": "^1.2.0",


### PR DESCRIPTION
Note: `codecov-action@v1` has been deprecrated https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1, so I've updated it to v2.